### PR TITLE
zephyr: module.yml: give name to module

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,4 @@
+name: zsdk
 build:
   cmake: .
   kconfig: Kconfig.nxp


### PR DESCRIPTION
If a name for the module is not specified, zephyr fills in the name based on the directory where the module is placed. Since the module itself depends on the name being zsdk, it's best to name it explicitely.

resolves https://github.com/nxp-zephyr/nxp-zsdk/issues/2